### PR TITLE
Fix array-like parameter serialization in rosbridge get_param (#1018)

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -164,6 +164,10 @@ async def get_param(node_name: str, name: str, params_glob: str) -> str:
     pvalue = await _get_param(node_name, name)
     value = getattr(pvalue, _parameter_type_mapping[pvalue.type])
 
+    # Convert array types to lists for JSON serialization
+    if hasattr(value, "tolist"):  # This will catch numpy arrays and Python arrays
+        value = value.tolist()
+
     return dumps(value)
 
 


### PR DESCRIPTION
* Update params.py

* Update rosapi/src/rosapi/params.py



* Update rosapi/src/rosapi/params.py



---------